### PR TITLE
feat(db): add comment, like, playlist, and tweet models

### DIFF
--- a/src/models/comment.model.js
+++ b/src/models/comment.model.js
@@ -1,0 +1,27 @@
+import mongoose from "mongoose";
+import { Schema } from "mongoose";
+import mongooseAggregatePaginate, {
+  mongoose,
+} from "mongoose-aggregate-paginate-v2";
+
+const commentSchema = new Schema(
+  {
+    content: {
+      type: String,
+      required: true,
+    },
+    owner: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+    },
+    video: {
+      type: Schema.Types.ObjectId,
+      ref: "Video",
+    },
+  }, 
+  { timestamps: true }
+);
+
+commentSchema.plugin(mongooseAggregatePaginate);
+
+export const Comment = mongoose.model("Comment", commentSchema);

--- a/src/models/likes.model.js
+++ b/src/models/likes.model.js
@@ -1,0 +1,21 @@
+import mongoose, { Schema } from "mongoose";
+
+const likeSchema = new Schema(
+  {
+    video: {
+      type: Schema.Types.ObjectId,
+      ref: "Video",
+    },
+    Comment: {
+      type: Schema.Types.ObjectId,
+      ref: "Comment",
+    },
+    likedBy: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+    },
+  },
+  { timestamps: true }
+);
+
+export const Like = mongoose.model("Like", likeSchema);

--- a/src/models/playlist.model.js
+++ b/src/models/playlist.model.js
@@ -1,0 +1,26 @@
+import mongoose, { Schema } from "mongoose";
+
+const playlistSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+    },
+    videos: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: "video",
+      },
+    ],
+    owner: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+    },
+  },
+  { timestamps: true }
+);
+
+export const Playlist = mongoose.model("Playlist", playlistSchema);

--- a/src/models/tweet.model.js
+++ b/src/models/tweet.model.js
@@ -1,0 +1,17 @@
+import mongoose, { Schema } from "mongoose";
+
+const tweetSchema = new mongoose.Schema(
+  {
+    owner: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+    },
+    content: {
+      type: String,
+      required: true,
+    },
+  },
+  { timestamps: true }
+);
+
+export const Tweet = mongoose.model("Tweet", tweetSchema);


### PR DESCRIPTION
- Create Mongoose models for core social features
- Add commentSchema with content, owner, and video references
- Implement likeSchema supporting likes on videos and comments
- Introduce playlistSchema for user-created video collections
- Add tweetSchema for short-form user posts
- All models include timestamps and proper relationships
- Enable pagination support for comments via mongoose-aggregate-paginate-v2